### PR TITLE
Use backslash in github branch | SRENEW-1117

### DIFF
--- a/__tests__/mocks/mocks.ts
+++ b/__tests__/mocks/mocks.ts
@@ -11,7 +11,8 @@ export const mockDeploy: FluxDeployConfig = {
   name: 'mock',
   namespace: 'mock-ns',
   kustomization: {
-    path: './kustomization/mock'
+    path: './kustomization/mock',
+    branch: 'main'
   },
   gitRepo: {
     branch: 'main',

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -9,6 +9,7 @@ export interface FluxDeployConfig {
   namespace: string
   kustomization: {
     path: string
+    branch: string
   }
   gitRepo: {
     branch: string
@@ -41,7 +42,7 @@ export function fluxDeploy(d: FluxDeployConfig, api = K8sApi()): Deploy {
       targetNamespace: d.namespace,
       postBuild: {
         substitute: {
-          branch: d.gitRepo.branch,
+          branch: d.kustomization.branch,
           image_tag: d.imageTag
         }
       }

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,7 @@ import {PullRequestEvent} from '@octokit/webhooks-types' // eslint-disable-line 
 import {fluxDeploy} from './deploy'
 import {handlePullRequest} from './pullrequest'
 
-import {slugurlref} from './slug'
+import {removeRef, slugurlref} from './slug'
 
 const INPUT_PIPELINE_PATH = 'pipelinePath'
 const INPUT_PIPELINE_REPO = 'pipelineRepo'
@@ -44,7 +44,7 @@ async function run(): Promise<void> {
         path: pipelinePath
       },
       gitRepo: {
-        branch,
+        branch: removeRef(ref),
         secretName: gitSecret,
         url: pipelineRepo
       },

--- a/src/main.ts
+++ b/src/main.ts
@@ -41,7 +41,8 @@ async function run(): Promise<void> {
       name,
       namespace,
       kustomization: {
-        path: pipelinePath
+        path: pipelinePath,
+        branch
       },
       gitRepo: {
         branch: removeRef(ref),


### PR DESCRIPTION
Isolated kustomization.branch and github.branch since they have different constraints on characters.